### PR TITLE
Release 2.5.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+.coverage
+.npmrc
+.scannerwork
+node_modules
+npm-debug.log
+package-lock.json
+.test
+/test
+.istanbul.yml
+.gitignore
+.travis.yml
+sonar-project.properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Upgrade sinon version to 6.0.0.
 
+### Fixed
+- Avoid npm distribution of unneeded files.
+
 ## [2.4.0] - 2018-06-02
 ### Changed
 - Upgrade sinon and sinon-chai versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [2.5.0] - 2018-06-17
+### Added
+- Expose chai "assert" method
+
+### Changed
+- Upgrade sinon version to 6.0.0.
+
 ## [2.4.0] - 2018-06-02
 ### Changed
 - Upgrade sinon and sinon-chai versions.

--- a/index.js
+++ b/index.js
@@ -16,5 +16,6 @@ module.exports = {
   describe: describe,
   it: it,
   expect: chai.expect,
+  assert: chai.assert,
   sinon: sinon
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-sinon-chai",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Wrapper for Mocha, Sinon and Chai. Wrapper cli for istanbul and mocha. Avoid globals in tests",
   "main": "index.js",
   "keywords": [
@@ -29,12 +29,12 @@
     "chai": "4.1.2",
     "dirty-chai": "2.0.1",
     "mocha": "5.2.0",
-    "sinon": "5.0.10",
+    "sinon": "6.0.0",
     "sinon-chai": "3.1.0",
     "istanbul": "0.4.5"
   },
   "devDependencies": {
-    "coveralls": "3.0.0",
+    "coveralls": "3.0.1",
     "standard": "11.0.1"
   },
   "author": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=mocha-sinon-chai
-sonar.projectVersion=2.4.0
+sonar.projectVersion=2.5.0
 
 sonar.sources=.
 sonar.exclusions=node_modules/**

--- a/test/index.specs.js
+++ b/test/index.specs.js
@@ -34,6 +34,11 @@ test.describe('index', () => {
     test.expect(test.expect).to.deep.equal(chai.expect)
   })
 
+  test.it('should return chai "assert" method', () => {
+    test.expect(test.assert).to.not.be.undefined()
+    test.expect(test.assert).to.deep.equal(chai.assert)
+  })
+
   test.it('should return sinon', () => {
     test.expect(test.sinon).to.not.be.undefined()
     test.expect(test.sinon).to.deep.equal(sinon)


### PR DESCRIPTION
### Added
- Expose chai "assert" method

### Changed
- Upgrade sinon version to 6.0.0.

### Fixed
- Avoid npm distribution of unneeded files.

closes #10 , closes #11 